### PR TITLE
Disable Scroll search

### DIFF
--- a/src/main/java/org/codelibs/elasticsearch/df/content/DataContent.java
+++ b/src/main/java/org/codelibs/elasticsearch/df/content/DataContent.java
@@ -15,10 +15,13 @@ public abstract class DataContent {
     protected ChannelBuffer channelBuffer;
 
     protected Client client;
+    
+    protected boolean disableScroll;
 
     public DataContent(final Client client, final RestRequest request) {
         this.client = client;
         this.request = request;
+        this.disableScroll = request.paramAsBoolean("disableScroll", false);
     }
 
     public abstract void write(File outputFile, SearchResponse response,

--- a/src/main/java/org/codelibs/elasticsearch/df/content/DataContent.java
+++ b/src/main/java/org/codelibs/elasticsearch/df/content/DataContent.java
@@ -2,6 +2,7 @@ package org.codelibs.elasticsearch.df.content;
 
 import java.io.File;
 
+import org.codelibs.elasticsearch.df.util.RequestUtil;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
@@ -21,7 +22,7 @@ public abstract class DataContent {
     public DataContent(final Client client, final RestRequest request) {
         this.client = client;
         this.request = request;
-        this.disableScroll = request.paramAsBoolean("disableScroll", false);
+        this.disableScroll = RequestUtil.disableScroll(request);
     }
 
     public abstract void write(File outputFile, SearchResponse response,

--- a/src/main/java/org/codelibs/elasticsearch/df/content/csv/CsvContent.java
+++ b/src/main/java/org/codelibs/elasticsearch/df/content/csv/CsvContent.java
@@ -171,7 +171,7 @@ public class CsvContent extends DataContent {
                     csvWriter.writeValues(dataList);
                 }
 
-                if (size == 0) {
+                if (size == 0 || disableScroll) {
                     // end
                     csvWriter.flush();
                     close();

--- a/src/main/java/org/codelibs/elasticsearch/df/content/json/JsonContent.java
+++ b/src/main/java/org/codelibs/elasticsearch/df/content/json/JsonContent.java
@@ -95,7 +95,7 @@ public class JsonContent extends DataContent {
                     writer.append(source).append('\n');
                 }
 
-                if (size == 0) {
+                if (size == 0 || disableScroll) {
                     // end
                     writer.flush();
                     close();

--- a/src/main/java/org/codelibs/elasticsearch/df/content/xls/XlsContent.java
+++ b/src/main/java/org/codelibs/elasticsearch/df/content/xls/XlsContent.java
@@ -203,7 +203,7 @@ public class XlsContent extends DataContent {
 
                 }
 
-                if (size == 0) {
+                if (size == 0 || disableScroll) {
                     OutputStream stream = null;
                     try {
                         stream = new BufferedOutputStream(new FileOutputStream(

--- a/src/main/java/org/codelibs/elasticsearch/df/rest/RestDataAction.java
+++ b/src/main/java/org/codelibs/elasticsearch/df/rest/RestDataAction.java
@@ -100,8 +100,10 @@ public class RestDataAction extends BaseRestHandler {
             }
 
             prepareSearch.setSearchType(request.param("search_type"));
+            
+            RequestUtil.setScroll(request, prepareSearch);
 
-            prepareSearch.setScroll(RequestUtil.getScroll(request));
+//            prepareSearch.setScroll(RequestUtil.getScroll(request));
 
             final String[] types = request.paramAsStringArray("type",
                     emptyStrings);

--- a/src/main/java/org/codelibs/elasticsearch/df/util/RequestUtil.java
+++ b/src/main/java/org/codelibs/elasticsearch/df/util/RequestUtil.java
@@ -21,9 +21,12 @@ public class RequestUtil {
 
 	public static void setScroll(RestRequest request,
 			SearchRequestBuilder prepareSearch) {
-		final boolean disableScroll = request.paramAsBoolean("disableScroll", false);
-		if(!disableScroll) {
+		if(!disableScroll(request)) {
 			prepareSearch.setScroll(RequestUtil.getScroll(request));
 		}
+	}
+	
+	public static boolean disableScroll(RestRequest request) {
+		return request.paramAsBoolean("from", false) || request.paramAsBoolean("size", false);
 	}
 }

--- a/src/main/java/org/codelibs/elasticsearch/df/util/RequestUtil.java
+++ b/src/main/java/org/codelibs/elasticsearch/df/util/RequestUtil.java
@@ -2,6 +2,7 @@ package org.codelibs.elasticsearch.df.util;
 
 import static org.elasticsearch.common.unit.TimeValue.parseTimeValue;
 
+import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.rest.RestRequest;
 
@@ -17,4 +18,12 @@ public class RequestUtil {
             return new TimeValue(60000);
         }
     }
+
+	public static void setScroll(RestRequest request,
+			SearchRequestBuilder prepareSearch) {
+		final boolean disableScroll = request.paramAsBoolean("disableScroll", false);
+		if(!disableScroll) {
+			prepareSearch.setScroll(RequestUtil.getScroll(request));
+		}
+	}
 }

--- a/src/main/java/org/codelibs/elasticsearch/df/util/RequestUtil.java
+++ b/src/main/java/org/codelibs/elasticsearch/df/util/RequestUtil.java
@@ -27,6 +27,6 @@ public class RequestUtil {
 	}
 	
 	public static boolean disableScroll(RestRequest request) {
-		return request.paramAsBoolean("from", false) || request.paramAsBoolean("size", false);
+		return request.paramAsBoolean("from", false);
 	}
 }


### PR DESCRIPTION
Issue: https://github.com/codelibs/elasticsearch-dataformat/issues/8
Right now the plugin by default uses scroll search which downloads the
entire result set even if from and size are mentioned.
To disable this and provide an option to limit the size have introduced
New URL param - "disableScroll" and the logic to disable scrolled es
search if its set to true.
curl -o /tmp/data.csv -XGET
"localhost:9200/{index}/{type}/_data?format=csv&disableScroll=true&source=..."
If disableScroll is set to true in url param - The downloaded file
content will be by limited to elasticsearch default rows returned. In
case from and size is mentioned as part of query or url param the
download rows will be limited to from and size