### PR TITLE
Modify Multi types dump for CSV & add unit tests

### DIFF
--- a/src/main/java/org/codelibs/elasticsearch/df/content/ContentType.java
+++ b/src/main/java/org/codelibs/elasticsearch/df/content/ContentType.java
@@ -6,7 +6,13 @@ import org.codelibs.elasticsearch.df.content.xls.XlsContent;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.rest.RestRequest;
 
+/**
+ * ContentType is a factory interface with 4 enumerated values
+ */
 public enum ContentType {
+
+    // these variables are value of this enum type ContentType
+    // they are by default public static final
     CSV(10) {
         @Override
         public String contentType() {
@@ -109,6 +115,7 @@ public enum ContentType {
 
     private int index;
 
+    // pass one argument into their values
     ContentType(final int index) {
         this.index = index;
     }
@@ -117,9 +124,17 @@ public enum ContentType {
         return index;
     }
 
+    // every enum value should implement all the abstract method in their enum type
     public abstract String contentType();
 
-    public abstract String fileName(RestRequest request);
-
+    /**
+     * Create a {@link DataContent} object associated with this {@link ContentType}
+     * to do the dump operations.
+     * @param client
+     * @param request
+     * @return
+     */
     public abstract DataContent dataContent(Client client, RestRequest request);
+
+    public abstract String fileName(RestRequest request);
 }

--- a/src/main/java/org/codelibs/elasticsearch/df/content/DataContent.java
+++ b/src/main/java/org/codelibs/elasticsearch/df/content/DataContent.java
@@ -25,6 +25,10 @@ public abstract class DataContent {
     public abstract void write(File outputFile, SearchResponse response, RestChannel channel,
             ActionListener<Void> listener);
 
+    public RestRequest getRequest() {
+        return request;
+    }
+
     public ContentType getContentType() {
         return contentType;
     }


### PR DESCRIPTION
Previously when we want to dump an index with several types such as `dataset0/item0,item1/_data`, if we want to add the header, as we write header to the file just in the fist scroll search, there might be other 'heads' added in the header set after, so I moved the 'write header' operation in the end after all the data dumped, and added unit test for it.