### PR TITLE
Add support for a new output format : JSON object list 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Elasticsearch Data Format Plugin
 ## Overview
 
 Elasticsearch Data Format Plugin provides a feature to allow you to download a response of a search result as several formats other than JSON.
-The supported formats are CSV, Excel and JSON(Bulk).
+The supported formats are CSV, Excel, JSON(Bulk) and JSON(Object List).
 
 ## Version
 
@@ -66,4 +66,12 @@ If not, it's as scan query(all data are stored.).
 | source            | string  | [Query DSL](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html) |
 | bulk.index        | string  | Index name in Bulk file |
 | bulk.type         | string  | Type name in Bulk file |
+
+### JSON (Object List format)
+
+    $ curl -o /tmp/data.json -XGET "localhost:9200/{index}/{type}/_data?format=jsonlist&source=..."
+
+| Request Parameter |  Type  | Description                                                  |
+| :---------------- | :----: | :----------------------------------------------------------- |
+| source            | string | [Query DSL](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html) |
 

--- a/src/main/java/org/codelibs/elasticsearch/df/content/ContentType.java
+++ b/src/main/java/org/codelibs/elasticsearch/df/content/ContentType.java
@@ -2,6 +2,7 @@ package org.codelibs.elasticsearch.df.content;
 
 import org.codelibs.elasticsearch.df.content.csv.CsvContent;
 import org.codelibs.elasticsearch.df.content.json.JsonContent;
+import org.codelibs.elasticsearch.df.content.json.JsonListContent;
 import org.codelibs.elasticsearch.df.content.xls.XlsContent;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.rest.RestRequest;
@@ -94,6 +95,27 @@ public enum ContentType {
                 return "_all.xlsx";
             }
             return index + ".xlsx";
+        }
+    },
+    JSONLIST(50) {
+        @Override
+        public String contentType() {
+            return "application/json";
+        }
+
+        @Override
+        public DataContent dataContent(final Client client,
+                final RestRequest request) {
+            return new JsonListContent(client, request, this);
+        }
+
+        @Override
+        public String fileName(final RestRequest request) {
+            final String index = request.param("index");
+            if (index == null) {
+                return "_all.json";
+            }
+            return index + ".json";
         }
     };
 

--- a/src/main/java/org/codelibs/elasticsearch/df/content/json/JsonListContent.java
+++ b/src/main/java/org/codelibs/elasticsearch/df/content/json/JsonListContent.java
@@ -1,0 +1,134 @@
+package org.codelibs.elasticsearch.df.content.json;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.codelibs.elasticsearch.df.content.ContentType;
+import org.codelibs.elasticsearch.df.content.DataContent;
+import org.codelibs.elasticsearch.df.util.RequestUtil;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+
+public class JsonListContent extends DataContent {
+    private static final Logger logger = LogManager.getLogger(JsonListContent.class);
+
+    public JsonListContent(final Client client, final RestRequest request, final ContentType contentType) {
+        super(client, request, contentType);
+    }
+
+    @Override
+    public void write(final File outputFile, final SearchResponse response, final RestChannel channel,
+            final ActionListener<Void> listener) {
+        try {
+            final OnLoadListener onLoadListener = new OnLoadListener(
+                    outputFile, listener);
+            onLoadListener.onResponse(response);
+        } catch (final Exception e) {
+            listener.onFailure(new ElasticsearchException("Failed to write data.",
+                    e));
+        }
+    }
+
+    protected class OnLoadListener implements ActionListener<SearchResponse> {
+        protected ActionListener<Void> listener;
+
+        protected Writer writer;
+
+        protected File outputFile;
+
+        private long currentCount = 0;
+
+        private boolean firstLine = true;
+
+        protected OnLoadListener(final File outputFile, final ActionListener<Void> listener) {
+            this.outputFile = outputFile;
+            this.listener = listener;
+            try {
+                writer = new BufferedWriter(new OutputStreamWriter(
+                        new FileOutputStream(outputFile), "UTF-8"));
+            } catch (final Exception e) {
+                throw new ElasticsearchException("Could not open "
+                        + outputFile.getAbsolutePath(), e);
+            }
+            try {
+                writer.append('[');
+            }catch (final Exception e) {
+                onFailure(e);
+            }
+        }
+
+        @Override
+        public void onResponse(final SearchResponse response) {
+            final String scrollId = response.getScrollId();
+            final SearchHits hits = response.getHits();
+            final int size = hits.getHits().length;
+            currentCount += size;
+            if (logger.isDebugEnabled()) {
+                logger.debug("scrollId: {}, totalHits: {}, hits: {}, current: {}",
+                        scrollId, hits.getTotalHits(), size, currentCount);
+            }
+            try {
+                for (final SearchHit hit : hits) {
+                    final String source = XContentHelper.convertToJson(
+                            hit.getSourceRef(), true, false, XContentType.JSON);
+                    if (!firstLine){
+                        writer.append(',');
+                    }else{
+                        firstLine = false;
+                    }
+                    writer.append('\n').append(source);
+                }
+
+                if (size == 0 || scrollId == null) {
+                    // end
+                    writer.append('\n').append(']');
+                    writer.flush();
+                    close();
+                    listener.onResponse(null);
+                } else {
+                    client.prepareSearchScroll(scrollId)
+                            .setScroll(RequestUtil.getScroll(request))
+                            .execute(this);
+                }
+            } catch (final Exception e) {
+                onFailure(e);
+            }
+        }
+
+        @Override
+        public void onFailure(final Exception e) {
+            try {
+                close();
+            } catch (final Exception e1) {
+                // ignore
+            }
+            listener.onFailure(new ElasticsearchException("Failed to write data.",
+                    e));
+        }
+
+        private void close() {
+            if (writer != null) {
+                try {
+                    writer.close();
+                } catch (final IOException e) {
+                    throw new ElasticsearchException("Could not close "
+                            + outputFile.getAbsolutePath(), e);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/codelibs/elasticsearch/df/rest/RestDataAction.java
+++ b/src/main/java/org/codelibs/elasticsearch/df/rest/RestDataAction.java
@@ -129,6 +129,9 @@ public class RestDataAction extends BaseRestHandler {
                 || "application/json".equals(contentType)
                 || "json".equalsIgnoreCase(contentType)) {
             return ContentType.JSON;
+        } else if ("application/list+json".equals(contentType)
+                || "jsonlist".equals(contentType)) {
+            return ContentType.JSONLIST;
         }
 
         return null;


### PR DESCRIPTION
- add new JSON object list output format
>[
&nbsp;&nbsp;&nbsp;{"aaa": "test 1","bbb": 1,"ccc":"2012-01-01:00:00.000Z", ...},
&nbsp;&nbsp;&nbsp;{"aaa": "test 2","bbb": 2,"ccc":"2012-01-01:00:00.000Z", ...},
&nbsp;&nbsp;&nbsp;{"aaa": "test 3","bbb": 3,"ccc":"2012-01-01:00:00.000Z", ...}
]
- update README for this new format
- update test cases for this new format